### PR TITLE
TTYG-178 Consistently use "`str`" instead of "string"

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -26,7 +26,7 @@ A reference dataset is a list of question "template" dicts, each of which contai
             - Retrieval: tool-specific arguments
             - Time-series: keys such as `mrid`, `limit`
             - Data points: keys such as `external_id`, `granularity`, `aggregates`, `start`, `end`, `limit`
-        - `output` (string): Expected output. For steps that compare structured results, provide a JSON-encoded string of the structure (e.g., SPARQL JSON results, retrieval contexts).
+        - `output` (`str`): Expected output. For steps that compare structured results, provide a JSON-encoded string of the structure (e.g., SPARQL JSON results, retrieval contexts).
         - `output_media_type`: (optional, one of: missing, `application/sparql-results+json`, `application/json`) Controls how `output` is parsed and compared to actual output
         - `ordered`: (optional; default `false`) For SPARQL `SELECT` steps, whether row order matters. `true`: the actual result rows must be in the same order; `false`: result rows are matched as a set. Ignored for other step types.
         - `required_columns`: (optional list) For SPARQL `SELECT` steps, binding names required for query results that must match
@@ -46,8 +46,8 @@ The target data is a dict mapping each reference item `id` to one response recor
         - Retrieval steps (`name == "retrieval"`): must include `k` (the cutoff) so that ID-based recall@k can be computed against reference retrieval contexts.
         - Time series (`name == "retrieve_time_series"`): typically includes `mrid`, `limit`.
         - Data points (`name == "retrieve_data_points"`): typically includes `external_id`, `granularity`, `aggregates`, `start`, `end`, `limit`.
-    - `status` (string): Required for step matching and step aggregation. Steps with `status == "success"` are eligible for matching; steps with `status == "error"` are counted as step errors in aggregate metrics.
-    - `output` (string): The actual output from the step. Required for successful steps that may be matched; ignored for steps with `status == "error"`
+    - `status` (`str`): Required for step matching and step aggregation. Steps with `status == "success"` are eligible for matching; steps with `status == "error"` are counted as step errors in aggregate metrics.
+    - `output` (`str`): The actual output from the step. Required for successful steps that may be matched; ignored for steps with `status == "error"`
         - Retrieval: a JSON array of context objects. Each object should contain an `id` (required for ID-based recall@k). If you want text-based retrieval metrics (LLM-backed) to run, include the context text as well (e.g., `{"id": "...", "text": "..."}`).
         - SPARQL: a JSON object in SPARQL Results JSON format for `SELECT` or `ASK`.
     - `execution_timestamp`: Required for `retrieve_data_points` step comparison; used as the anchor for relative `start`/`end` times

--- a/docs/steps.md
+++ b/docs/steps.md
@@ -27,7 +27,7 @@ The matching algorithm is as follows:
 - If all steps in the group are matched, then proceed to the previous group, matching actual steps executed before the earliest actual step already matched for the current group.
 - If some steps in the group are not matched, then stop matching and compute the score from the matches found so far.
 
-The output contains section `reference_steps` structured as the input `reference_steps`. Each matched reference step includes the additional key `matches` (string) containing `<actual_step.id>` of the matching actual step.
+The output contains section `reference_steps` structured as the input `reference_steps`. Each matched reference step includes the additional key `matches` (`str`) containing `<actual_step.id>` of the matching actual step.
 
 ## Match score
 
@@ -101,9 +101,9 @@ Otherwise, the match score is 0.
 
 Data points are compared using the following algorithm:
 - Compare:
-    - `args.external_id` (string or list; strings are converted to one-item lists, and lists are sorted)
-    - `args.granularity` (unit-normalized; e.g., `15m` equals `15minutes`)
-    - `args.aggregates` (string or list; strings are converted to one-item lists, and lists are sorted)
+    - `args.external_id` (`str` or `list`; strings are converted to one-item lists, and lists are sorted)
+    - `args.granularity` (`str`; unit-normalized; e.g., `15m` equals `15minutes`)
+    - `args.aggregates` (`str` or `list`; strings are converted to one-item lists, and lists are sorted)
     - `args.limit`
 - Compare `args.start` and `args.end` anchored to the actual step's `execution_timestamp`:
     - If the reference time is relative (`now`, `Xs-ago`/`Xm-ago`/`Xh-ago`/`Xd-ago`/`Xw-ago`, and their `-ahead` equivalents) and the actual time is absolute, resolve the reference against `execution_timestamp` and accept if within 60 seconds.


### PR DESCRIPTION
Closes [TTYG-178](https://graphwise.atlassian.net/browse/TTYG-178) .